### PR TITLE
Changed class "help-block" to "text-muted" for v4

### DIFF
--- a/src/View/Helper/BootstrapFormHelper.php
+++ b/src/View/Helper/BootstrapFormHelper.php
@@ -368,7 +368,7 @@ class BootstrapFormHelper extends FormHelper {
         $help = $this->_extractOption('help', $options, '');
         unset($options['help']);
         if ($help) {
-            $append .= '<p class="help-block">'.$help.'</p>' ;
+            $append .= '<small class="text-muted">'.$help.'</small>' ;
         }
         
         $type = strtolower($options['type']) ;


### PR DESCRIPTION
New bootstrap style for help blocks under input fields is:
```html
<small class="text-muted">Some additional information</small>
```