### PR TITLE
Add support for passing class to custom File btn/input

### DIFF
--- a/src/View/Helper/BootstrapFormHelper.php
+++ b/src/View/Helper/BootstrapFormHelper.php
@@ -454,19 +454,24 @@ class BootstrapFormHelper extends FormHelper {
             'style' => 'display: none;',
             'onchange' => "document.getElementById('".$options['id']."-input').value = (this.files.length <= 1) ? this.files[0].name : this.files.length + ' ' + '" . $countLabel . "';"
         ]));
-        $fakeInput = $this->text($fieldName, array_merge($options, [
+
+        $fakeInputCustomOptions = $this->_extractOption('_input', $options, []);
+        unset($options['_input']);
+        $fakeButtonCustomOptions = $this->_extractOption('_button', $options, []);
+        unset($options['_button']);
+
+        $fakeInput = $this->text($fieldName, array_merge($options, $fakeInputCustomOptions, [
             'readonly' => 'readonly',
             'id' => $options['id'].'-input',
-            'onclick' => "document.getElementById('".$options['id']."').click();",
-            'class' => $options['input-class']
+            'onclick' => "document.getElementById('".$options['id']."').click();"
         ]));
         $buttonLabel = $this->_extractOption('button-label', $options, __('Choose File'));
         unset($options['button-label']) ;
-        $fakeButton = $this->button($buttonLabel, [
+
+        $fakeButton = $this->button($buttonLabel, array_merge($fakeButtonCustomOptions, [
             'type' => 'button',
-            'onclick' => "document.getElementById('".$options['id']."').click();",
-            'class' => $options['button-class']
-        ]);
+            'onclick' => "document.getElementById('".$options['id']."').click();"
+        ]));
         return $fileInput.$this->Html->div('input-group', $this->Html->div('input-group-btn', $fakeButton).$fakeInput) ;
     }
 

--- a/src/View/Helper/BootstrapFormHelper.php
+++ b/src/View/Helper/BootstrapFormHelper.php
@@ -441,9 +441,13 @@ class BootstrapFormHelper extends FormHelper {
         if (!$this->_customFileInput || (isset($options['default']) && $options['default'])) {
             return parent::file($fieldName, $options);
         }
-        if (!isset($options['id'])) {
-            $options['id'] = $fieldName ;
-        }
+        $defaultOptions = [
+            'id' => $fieldName,
+            'button-class' => '',
+            'input-class' => ''
+        ];
+        $options = array_merge($options, $defaultOptions);
+
         $options += ['secure' => true];
         $options = $this->_initInputField($fieldName, $options);
         unset($options['type']);

--- a/src/View/Helper/BootstrapFormHelper.php
+++ b/src/View/Helper/BootstrapFormHelper.php
@@ -460,13 +460,15 @@ class BootstrapFormHelper extends FormHelper {
         $fakeInput = $this->text($fieldName, array_merge($options, [
             'readonly' => 'readonly',
             'id' => $options['id'].'-input',
-            'onclick' => "document.getElementById('".$options['id']."').click();"
+            'onclick' => "document.getElementById('".$options['id']."').click();",
+            'class' => $options['input-class']
         ]));
         $buttonLabel = $this->_extractOption('button-label', $options, __('Choose File'));
         unset($options['button-label']) ;
         $fakeButton = $this->button($buttonLabel, [
             'type' => 'button',
-            'onclick' => "document.getElementById('".$options['id']."').click();"
+            'onclick' => "document.getElementById('".$options['id']."').click();",
+            'class' => $options['button-class']
         ]);
         return $fileInput.$this->Html->div('input-group', $this->Html->div('input-group-btn', $fakeButton).$fakeInput) ;
     }

--- a/src/View/Helper/BootstrapFormHelper.php
+++ b/src/View/Helper/BootstrapFormHelper.php
@@ -446,7 +446,7 @@ class BootstrapFormHelper extends FormHelper {
             'button-class' => '',
             'input-class' => ''
         ];
-        $options = array_merge($options, $defaultOptions);
+        $options = array_merge($defaultOptions, $options);
 
         $options += ['secure' => true];
         $options = $this->_initInputField($fieldName, $options);

--- a/src/View/Helper/BootstrapFormHelper.php
+++ b/src/View/Helper/BootstrapFormHelper.php
@@ -441,12 +441,9 @@ class BootstrapFormHelper extends FormHelper {
         if (!$this->_customFileInput || (isset($options['default']) && $options['default'])) {
             return parent::file($fieldName, $options);
         }
-        $defaultOptions = [
-            'id' => $fieldName,
-            'button-class' => '',
-            'input-class' => ''
-        ];
-        $options = array_merge($defaultOptions, $options);
+        if (!isset($options['id'])) {
+            $options['id'] = $fieldName;
+        }
 
         $options += ['secure' => true];
         $options = $this->_initInputField($fieldName, $options);


### PR DESCRIPTION
This patch adds support for a `button-class` and `input-class` option in the `file()` method on the Form helper.  

This was to allow the passing of custom classes to those elements to help with more complex styling or tweaking, or just simply (in my actual use case) passing the `btn-sm` class to make the button smaller.

As I needed to set up some defaults for the new array keys I altered the way in which defaults options are handled so there won't be a chain of `if(isset)` operations for each key.