### PR TITLE
Add support for template variables.

### DIFF
--- a/src/View/BootstrapStringTemplate.php
+++ b/src/View/BootstrapStringTemplate.php
@@ -59,6 +59,10 @@ class BootstrapStringTemplate extends StringTemplate {
         if ($template === null) {
             return '';
         }
+        if (isset($data['templateVars'])) {
+            $data += $data['templateVars'];
+            unset($data['templateVars']);
+        }
         $replace = [];
         foreach ($placeholders as $placeholder) {
             $replace[] = isset($data[$placeholder]) ? $data[$placeholder] : null;


### PR DESCRIPTION
CakePHP 3.1 introduced template variables to support custom placeholders in templates.

refs cakephp/cakephp#6850
http://book.cakephp.org/3.0/en/views/helpers/form.html#adding-additional-template-variables-to-templates