### PR TITLE
Improve ModalHelper::Create size flexibility

### DIFF
--- a/src/View/Helper/BootstrapModalHelper.php
+++ b/src/View/Helper/BootstrapModalHelper.php
@@ -42,6 +42,7 @@ class BootstrapModalHelper extends Helper {
      * Extra options (useless if $title not specified) :
      *     - close: Add close buttons to header (default true)
      *     - no-body: Do not open the body after the create (default false)
+     *     - size: Modal size (small, large or custom classes)
     **/
     public function create($title = null, $options = array()) {
 
@@ -72,7 +73,7 @@ class BootstrapModalHelper extends Helper {
             $size = 'modal-sm';
             break;
         default:
-            $size = '';
+            $size = $options['size'];
             break;
         }
         unset($options['size']);


### PR DESCRIPTION
I use a custom 'modal-xl' class to make modals even larger than lg. For this to work, the modal helper needs to accepts a size class string it doesn't understand. I don't see an adverse effect in letting the user choose their own size class(es).

Also documentation did not mention this option before.