### PR TITLE
Fix issues with custom file input

### DIFF
--- a/src/View/Helper/BootstrapFormHelper.php
+++ b/src/View/Helper/BootstrapFormHelper.php
@@ -426,6 +426,12 @@ class BootstrapFormHelper extends FormHelper {
         if (!$this->_customFileInput || (isset($options['default']) && $options['default'])) {
             return parent::file($fieldName, $options);
         }
+
+        $fakeInputCustomOptions = $this->_extractOption('_input', $options, []);
+        unset($options['_input']);
+        $fakeButtonCustomOptions = $this->_extractOption('_button', $options, []);
+        unset($options['_button']);
+
         if (!isset($options['id'])) {
             $options['id'] = $fieldName;
         }
@@ -440,12 +446,8 @@ class BootstrapFormHelper extends FormHelper {
             'onchange' => "document.getElementById('".$options['id']."-input').value = (this.files.length <= 1) ? this.files[0].name : this.files.length + ' ' + '" . $countLabel . "';"
         ]));
 
-        $fakeInputCustomOptions = $this->_extractOption('_input', $options, []);
-        unset($options['_input']);
-        $fakeButtonCustomOptions = $this->_extractOption('_button', $options, []);
-        unset($options['_button']);
-
         $fakeInput = $this->text($fieldName, array_merge($options, $fakeInputCustomOptions, [
+            'name' => $fieldName.'-text',
             'readonly' => 'readonly',
             'id' => $options['id'].'-input',
             'onclick' => "document.getElementById('".$options['id']."').click();"


### PR DESCRIPTION
* Options passed via '_input' / '_button' can end up in the attributes of the hidden input element (`$fileInput`). To avoid this, these are extracted before creating the element, right at the beginning of the function.

* The text element (`$fakeInput`) causes an issue with the SecurityComponent:

> Missing field 'filename' in POST data
Cake\Controller\Exception\SecurityException

The reason is that both the file and filename are sent under the name of the field (here: 'filename'). We overwrite the 'name' option to fix this. Note that passing a different name as first argument would *not* fix this. The name is still part of $options and will set the html field name.