### PR TITLE
Add option for dropdownButton

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -665,12 +665,14 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
      * @return string A HTML string containing the button dropdown.
      */
     public function dropdownButton($title, array $menu = [], array $options = []) {
+        $align = (isset($options['align'])) ? $options['align'] : 'left';
+        unset($options['align']);
         $options['type'] = false;
         $options['data-toggle'] = 'dropdown';
         $options = $this->addClass($options, "dropdown-toggle");
         return $this->buttonGroup([
             $this->button($title.' <span class="caret"></span>', $options),
-            $this->Html->dropdown($menu)
+            $this->Html->dropdown($menu, ['class' => ["dropdown-menu-{$align}"]])
         ]);
 
     }


### PR DESCRIPTION
This pull add option "dropdown-menu-right".
To default, the dropdownButton is aligned to left.
The align property if it is set, waits for the 'right' or 'left' values.