### PR TITLE
Prepare for CakePHP 3.6: Remove deprecations

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -185,7 +185,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
                     'errorColumnClass' => $this->_getColumnClass('error'),
                     'inputColumnOffsetClass' => $this->_getColumnClass('label', true),
                 ];
-                if (!$that->templates($data['templateName'])) {
+                if (!$that->getTemplates($data['templateName'])) {
                     $data['templateName'] = $name;
                 }
                 return $data;

--- a/src/View/Helper/PanelHelper.php
+++ b/src/View/Helper/PanelHelper.php
@@ -322,7 +322,7 @@ class PanelHelper extends Helper {
         $out = $this->formatTemplate($current.'End', []);
         if ($this->_states->getValue('collapsible')) {
             $ctplt = $current.'CollapsibleEnd';
-            if ($this->templates($ctplt)) {
+            if ($this->getTemplates($ctplt)) {
                 $out = $this->formatTemplate($ctplt, [
                     $current.'End' => $out
                 ]);

--- a/src/View/Helper/UrlComparerTrait.php
+++ b/src/View/Helper/UrlComparerTrait.php
@@ -14,6 +14,7 @@
  */
 namespace Bootstrap\View\Helper;
 
+use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 
 
@@ -119,7 +120,7 @@ trait UrlComparerTrait {
         if (!$this->_matchRelative($url)) {
             return null;
         }
-        $url = Router::parse($this->_removeRelative($url));
+        $url = Router::parseRequest(new ServerRequest($this->_removeRelative($url)));
         $arr = [];
         foreach ($this->_parts as $part) {
             if (!isset($url[$part]) || (isset($parts[$part]) && !$parts[$part])) {

--- a/tests/TestCase/View/Helper/EasyIconTraitTest.php
+++ b/tests/TestCase/View/Helper/EasyIconTraitTest.php
@@ -164,7 +164,7 @@ class EasyIconTraitTest extends TestCase {
                 'aria-hidden' => 'true'
             ]], '/i', '/button'
         ], $result);
-        $result = $this->form->input('fieldname', [
+        $result = $this->form->control('fieldname', [
             'prepend' => 'i:home',
             'append'  => 'i:plus',
             'label'   => false

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -218,7 +218,7 @@ class FormHelperTest extends TestCase {
             unset($options['_formOptions']);
         }
         $this->form->create(null, $formOptions);
-        $result = $this->form->input($fieldName, $options);
+        $result = $this->form->control($fieldName, $options);
         $assert = $this->assertHtml($expected, $result, $debug);
     }
 
@@ -768,7 +768,7 @@ class FormHelperTest extends TestCase {
         $fieldName = 'field';
         // Add a template with the help placeholder.
         $help = 'Some help text.';
-        $this->form->templates([
+        $this->form->setTemplates([
             'inputContainer' => '<div class="form-group {{type}}{{required}}">{{content}}<span>{{help}}</span></div>'
         ]);
         // Standard form
@@ -985,7 +985,7 @@ class FormHelperTest extends TestCase {
         $this->assertHtml($expected, $result);
 
         // Test with input()
-        $result = $this->form->input('Contact.date', ['type' => 'date']);
+        $result = $this->form->control('Contact.date', ['type' => 'date']);
         $now = strtotime('now');
         $expected = [
             ['div' => [
@@ -1158,14 +1158,17 @@ class FormHelperTest extends TestCase {
         $result = $this->form->file('Contact.picture');
         $this->assertHtml($expected, $result);
 
-        $this->form->request->data['Contact']['picture'] = [
+        $this->form->request = $this->form->request->withData('Contact.picture', [
             'name' => '', 'type' => '', 'tmp_name' => '',
             'error' => 4, 'size' => 0
-        ];
+        ]);
         $result = $this->form->file('Contact.picture');
         $this->assertHtml($expected, $result);
 
-        $this->form->request->data['Contact']['picture'] = 'no data should be set in value';
+        $this->form->request = $this->form->request->withData(
+            'Contact.picture',
+            'no data should be set in value'
+        );
         $result = $this->form->file('Contact.picture');
         $this->assertHtml($expected, $result);
     }

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -44,8 +44,8 @@ class HtmlHelperTest extends TestCase {
         $this->assertHtml($expected, $result);
 
         // Custom templates
-        $oldTemplates = $this->html->templates();
-        $this->html->templates([
+        $oldTemplates = $this->html->getTemplates();
+        $this->html->setTemplates([
             'icon' => '<span class="fa fa-{{type}}{{attrs.class}}" data-type="{{type}}"{{attrs}}>{{inner}}</span>'
         ]);
         $result = $this->html->icon('home', [
@@ -79,7 +79,7 @@ class HtmlHelperTest extends TestCase {
             '/span'
         ];
         $this->assertHtml($expected, $result);
-        $this->html->templates($oldTemplates);
+        $this->html->setTemplates($oldTemplates);
 
     }
 

--- a/tests/TestCase/View/Helper/NavbarHelperTest.php
+++ b/tests/TestCase/View/Helper/NavbarHelperTest.php
@@ -4,7 +4,7 @@ namespace Bootstrap\Test\TestCase\View\Helper;
 
 use Bootstrap\View\Helper\NavbarHelper;
 use Cake\Core\Configure;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\Routing\Route\DashedRoute;
@@ -269,7 +269,7 @@ class NavbarHelperTest extends TestCase {
 
     public function testMenu() {
         // TODO: Add test for this...
-        $this->navbar->config('autoActiveLink', false);
+        $this->navbar->setConfig('autoActiveLink', false);
         // Basic test:
         $this->navbar->create(null);
         $result = $this->navbar->beginMenu(['class' => 'my-menu']);
@@ -319,7 +319,7 @@ class NavbarHelperTest extends TestCase {
         $this->navbar->beginMenu('');
 
         // Active and correct link:
-        $this->navbar->config('autoActiveLink', true);
+        $this->navbar->setConfig('autoActiveLink', true);
         $result = $this->navbar->link('Link', '/');
         $expected = [
             ['li' => ['class' => 'active']],
@@ -329,7 +329,7 @@ class NavbarHelperTest extends TestCase {
         $this->assertHtml($expected, $result);
 
         // Active and incorrect link but more complex:
-        $this->navbar->config('autoActiveLink', true);
+        $this->navbar->setConfig('autoActiveLink', true);
         $result = $this->navbar->link('Link', '/pages');
         $expected = [
             ['li' => []],
@@ -339,7 +339,7 @@ class NavbarHelperTest extends TestCase {
         $this->assertHtml($expected, $result);
 
         // Unactive and correct link:
-        $this->navbar->config('autoActiveLink', false);
+        $this->navbar->setConfig('autoActiveLink', false);
         $result = $this->navbar->link('Link', '/');
         $expected = [
             ['li' => []],
@@ -349,7 +349,7 @@ class NavbarHelperTest extends TestCase {
         $this->assertHtml($expected, $result);
 
         // Unactive and incorrect link:
-        $this->navbar->config('autoActiveLink', false);
+        $this->navbar->setConfig('autoActiveLink', false);
         $result = $this->navbar->link('Link', '/pages');
         $expected = [
             ['li' => []],
@@ -363,20 +363,20 @@ class NavbarHelperTest extends TestCase {
         Router::scope('/', function (RouteBuilder $routes) {
             $routes->fallbacks(DashedRoute::class);
         });
-        Router::fullBaseUrl('');
+        Router::fullBaseUrl('/cakephp/pages/view/1');
         Configure::write('App.fullBaseUrl', 'http://localhost');
-        $request = new Request();
-        $request->addParams([
-            'action' => 'view',
-            'plugin' => null,
-            'controller' => 'pages',
-            'pass' => ['1']
-        ]);
-        $request->base = '/cakephp';
-        $request->here = '/cakephp/pages/view/1';
+        $request = new ServerRequest();
+        $request = $request
+            ->withAttribute('params', [
+                'action' => 'view',
+                'plugin' => null,
+                'controller' => 'pages',
+                'pass' => ['1']
+            ])
+            ->withAttribute('base', '/cakephp');
         Router::setRequestInfo($request);
 
-        $this->navbar->config('autoActiveLink', true);
+        $this->navbar->setConfig('autoActiveLink', true);
         $result = $this->navbar->link('Link', '/pages', [
             'active' => ['action' => false, 'pass' => false]
         ]);
@@ -403,18 +403,18 @@ class NavbarHelperTest extends TestCase {
         });
         Router::fullBaseUrl('');
         Configure::write('App.fullBaseUrl', 'http://localhost');
-        $request = new Request();
-        $request->addParams([
-            'action' => 'display',
-            'plugin' => null,
-            'controller' => 'pages',
-            'pass' => ['faq']
-        ]);
-        $request->base = '/cakephp';
-        $request->here = '/cakephp/pages/faq';
+        $request = new ServerRequest('/cakephp/pages/faq');
+        $request = $request
+            ->withAttribute('params', [
+                'action' => 'display',
+                'plugin' => null,
+                'controller' => 'pages',
+                'pass' => ['faq']
+            ])
+            ->withAttribute('base', '/cakephp');
         Router::setRequestInfo($request);
 
-        $this->navbar->config('autoActiveLink', true);
+        $this->navbar->setConfig('autoActiveLink', true);
         $result = $this->navbar->link('Link', '/pages', [
             'active' => ['action' => false, 'pass' => false]
         ]);

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -31,9 +31,8 @@ class PaginatorHelperTest extends TestCase {
             'className' => 'Bootstrap.Html'
         ]);
         $this->paginator = new PaginatorHelper($view);
-        $this->paginator->request = new Request();
-        $this->paginator->request->addParams([
-            'paging' => [
+        $this->paginator->request = (new Request())
+            ->withParam('paging', [
                 'Article' => [
                     'page' => 1,
                     'current' => 9,
@@ -45,8 +44,7 @@ class PaginatorHelperTest extends TestCase {
                     'direction' => null,
                     'limit' => null,
                 ]
-            ]
-        ]);
+            ]);
         Configure::write('Routing.prefixes', []);
         Router::reload();
         Router::connect('/:controller/:action/*');
@@ -55,7 +53,7 @@ class PaginatorHelperTest extends TestCase {
 
     public function testNumbers()
     {
-        $this->paginator->request->params['paging'] = [
+        $this->paginator->request = $this->paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 8,
                 'current' => 3,
@@ -64,7 +62,7 @@ class PaginatorHelperTest extends TestCase {
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->paginator->numbers();
         $expected = [
             ['ul' => ['class' => 'pagination']],
@@ -137,7 +135,7 @@ class PaginatorHelperTest extends TestCase {
             '/ul'
         ];
         $this->assertHtml($expected, $result);
-        $this->paginator->request->params['paging'] = [
+        $this->paginator->request = $this->paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 1,
                 'current' => 3,
@@ -146,7 +144,7 @@ class PaginatorHelperTest extends TestCase {
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->paginator->numbers();
         $expected = [
             ['ul' => ['class' => 'pagination']],
@@ -162,7 +160,7 @@ class PaginatorHelperTest extends TestCase {
             '/ul'
         ];
         $this->assertHtml($expected, $result);
-        $this->paginator->request->params['paging'] = [
+        $this->paginator->request = $this->paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 14,
                 'current' => 3,
@@ -171,7 +169,7 @@ class PaginatorHelperTest extends TestCase {
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->paginator->numbers();
         $expected = [
             ['ul' => ['class' => 'pagination']],
@@ -187,7 +185,7 @@ class PaginatorHelperTest extends TestCase {
             '/ul'
         ];
         $this->assertHtml($expected, $result);
-        $this->paginator->request->params['paging'] = [
+        $this->paginator->request = $this->paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 2,
                 'current' => 3,
@@ -196,7 +194,7 @@ class PaginatorHelperTest extends TestCase {
                 'nextPage' => 2,
                 'pageCount' => 9,
             ]
-        ];
+        ]);
         $result = $this->paginator->numbers(['first' => 1]);
         $expected = [
             ['ul' => ['class' => 'pagination']],
@@ -227,7 +225,7 @@ class PaginatorHelperTest extends TestCase {
             '/ul'
         ];
         $this->assertHtml($expected, $result);
-        $this->paginator->request->params['paging'] = [
+        $this->paginator->request = $this->paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 15,
                 'current' => 3,
@@ -236,7 +234,7 @@ class PaginatorHelperTest extends TestCase {
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->paginator->numbers(['first' => 1]);
         $expected = [
             ['ul' => ['class' => 'pagination']],
@@ -254,7 +252,7 @@ class PaginatorHelperTest extends TestCase {
             '/ul'
         ];
         $this->assertHtml($expected, $result);
-        $this->paginator->request->params['paging'] = [
+        $this->paginator->request = $this->paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 10,
                 'current' => 3,
@@ -263,7 +261,7 @@ class PaginatorHelperTest extends TestCase {
                 'nextPage' => 2,
                 'pageCount' => 15,
             ]
-        ];
+        ]);
         $result = $this->paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
             ['ul' => ['class' => 'pagination']],
@@ -282,7 +280,7 @@ class PaginatorHelperTest extends TestCase {
             '/ul'
         ];
         $this->assertHtml($expected, $result);
-        $this->paginator->request->params['paging'] = [
+        $this->paginator->request = $this->paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 6,
                 'current' => 15,
@@ -291,7 +289,7 @@ class PaginatorHelperTest extends TestCase {
                 'nextPage' => 1,
                 'pageCount' => 42,
             ]
-        ];
+        ]);
         $result = $this->paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
             ['ul' => ['class' => 'pagination']],
@@ -310,7 +308,7 @@ class PaginatorHelperTest extends TestCase {
             '/ul'
         ];
         $this->assertHtml($expected, $result);
-        $this->paginator->request->params['paging'] = [
+        $this->paginator->request = $this->paginator->request->withParam('paging', [
             'Client' => [
                 'page' => 37,
                 'current' => 15,
@@ -319,7 +317,7 @@ class PaginatorHelperTest extends TestCase {
                 'nextPage' => 1,
                 'pageCount' => 42,
             ]
-        ];
+        ]);
         $result = $this->paginator->numbers(['first' => 1, 'last' => 1]);
         $expected = [
             ['ul' => ['class' => 'pagination']],

--- a/tests/TestCase/View/Helper/UrlComparerTraitTest.php
+++ b/tests/TestCase/View/Helper/UrlComparerTraitTest.php
@@ -4,7 +4,7 @@ namespace Bootstrap\Test\TestCase\View\Helper;
 
 use Bootstrap\View\Helper\UrlComparerTrait;
 use Cake\Core\Configure;
-use Cake\Network\Request;
+use Cake\Http\ServerRequest;
 use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\Routing\Route\DashedRoute;
@@ -63,15 +63,15 @@ class UrlComparerTraitTest extends TestCase {
         }
         Router::fullBaseUrl('');
         Configure::write('App.fullBaseUrl', 'http://localhost');
-        $request = new Request();
-        $request->addParams([
-            'action' => 'view',
-            'plugin' => null,
-            'controller' => 'pages',
-            'pass' => ['1']
-        ]);
-        $request->base = '/cakephp';
-        $request->here = '/cakephp/pages/view/1';
+        $request = new ServerRequest('/cakephp/pages/view/1');
+        $request = $request
+            ->withAttribute('params', [
+                'action' => 'view',
+                'plugin' => null,
+                'controller' => 'pages',
+                'pass' => ['1']
+            ])
+            ->withAttribute('base', '/cakephp');
         Router::setRequestInfo($request);
         $tests = [
             ['/pages', '/pages/display'],
@@ -132,15 +132,15 @@ class UrlComparerTraitTest extends TestCase {
         }
         Router::fullBaseUrl('');
         Configure::write('App.fullBaseUrl', 'http://localhost');
-        $request = new Request();
-        $request->addParams([
-            'action' => 'view',
-            'plugin' => null,
-            'controller' => 'pages',
-            'pass' => ['1']
-        ]);
-        $request->base = '/cakephp';
-        $request->here = '/cakephp/pages/view/1';
+        $request = new ServerRequest('/cakephp/pages/view/1');
+        $request = $request
+            ->withAttribute('params', [
+                'action' => 'view',
+                'plugin' => null,
+                'controller' => 'pages',
+                'pass' => ['1']
+            ])
+            ->withAttribute('base', '/cakephp');
         Router::setRequestInfo($request);
         $tests = [
             ['/pages', '/pages/display'],
@@ -224,15 +224,15 @@ class UrlComparerTraitTest extends TestCase {
     public function testFullBase() {
         Router::fullBaseUrl('');
         Configure::write('App.fullBaseUrl', 'http://localhost');
-        $request = new Request();
-        $request->addParams([
-            'action' => 'view',
-            'plugin' => null,
-            'controller' => 'pages',
-            'pass' => ['1']
-        ]);
-        $request->base = '/cakephp';
-        $request->here = '/cakephp/pages/view/1';
+        $request = new ServerRequest('/cakephp/pages/view/1');
+        $request = $request
+            ->withAttribute('params', [
+                'action' => 'view',
+                'plugin' => null,
+                'controller' => 'pages',
+                'pass' => ['1']
+            ])
+            ->withAttribute('base', '/cakephp');
         Router::setRequestInfo($request);
         $urlsMatchTrue = [
             // Test root
@@ -269,15 +269,15 @@ class UrlComparerTraitTest extends TestCase {
         ];
         $this->_testCompare($urlsMatchTrue, $urlsMatchFalse);
 
-        $request = new Request();
-        $request->addParams([
-            'action' => 'display',
-            'plugin' => null,
-            'controller' => 'pages',
-            'pass' => ['faq']
-        ]);
-        $request->base = '/cakephp';
-        $request->here = '/cakephp/pages/faq';
+        $request = new ServerRequest('/cakephp/pages/faq');
+        $request = $request
+            ->withAttribute('params', [
+                'action' => 'display',
+                'plugin' => null,
+                'controller' => 'pages',
+                'pass' => ['faq']
+            ])
+            ->withAttribute('base', '/cakephp');
         Router::setRequestInfo($request);
         $this->_testCompare([
             ['/pages/faq', []],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -48,7 +48,7 @@ Configure::write('App', [
     'wwwRoot' => WWW_ROOT
 ]);
 
-Cache::config([
+Cache::setConfig([
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',


### PR DESCRIPTION
Fix Tests and Helpers to remove deprecation warnings introduced in CakePHP 3.6