### PR TITLE
Update FormHelper.php

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -73,6 +73,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
             'checkboxWrapper' => '<div class="checkbox">{{label}}</div>',
             'checkboxContainer' => '<div class="checkbox {{required}}">{{content}}</div>',
             'checkboxContainerHorizontal' => '<div class="form-group"><div class="{{inputColumnOffsetClass}} {{inputColumnClass}}"><div class="checkbox {{required}}">{{content}}</div></div></div>',
+            'confirmJs' => '{{confirm}}',
             'dateWidget' => '<div class="row">{{year}}{{month}}{{day}}{{hour}}{{minute}}{{second}}{{meridian}}</div>',
             'error' => '<span class="help-block error-message">{{content}}</span>',
             'errorHorizontal' => '<span class="help-block error-message {{errorColumnClass}}">{{content}}</span>',


### PR DESCRIPTION
Fixes RuntimeException: Cannot find template named 'confirmJs' on CakePHP 3.7
