### PR TITLE
$this->request deprecated in CakePHP 3.7.0

### DIFF
--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -33,11 +33,11 @@ class FlashHelper extends \Cake\View\Helper\FlashHelper {
      * {@inheritDoc}
      */
     public function render($key = 'flash', array $options = []) {
-        if (!$this->request->getSession()->check("Flash.$key")) {
+        if (!$this->getView()->getRequest()->getSession()->check("Flash.$key")) {
             return;
         }
 
-        $flash = $this->request->getSession()->read("Flash.$key");
+        $flash = $this->getView()->getRequest()->getSession()->read("Flash.$key");
         if (!is_array($flash)) {
             throw new \UnexpectedValueException(sprintf(
                 'Value for flash setting key "%s" must be an array.',
@@ -49,7 +49,7 @@ class FlashHelper extends \Cake\View\Helper\FlashHelper {
                 $message['element'] = 'Bootstrap.'.$message['element'];
             }
         }
-        $this->request->getSession()->write("Flash.$key", $flash);
+        $this->getView()->getRequest()->getSession()->write("Flash.$key", $flash);
 
         return parent::render($key, $options);
     }


### PR DESCRIPTION
$this->request deprecated in CakePHP 3.7.0 use $this->getView()->getRequest() instead