### PR TITLE
Add confirmJs template in FormHelper.php to fix Cannot find template …

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -118,7 +118,8 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
             'helpBlock' => '<p class="help-block">{{content}}</p>',
             'buttonGroup' => '<div class="btn-group{{attrs.class}}"{{attrs}}>{{content}}</div>',
             'buttonToolbar' => '<div class="btn-toolbar{{attrs.class}}"{{attrs}}>{{content}}</div>',
-            'fancyFileInput' => '{{fileInput}}<div class="input-group"><div class="input-group-btn">{{button}}</div>{{input}}</div>'
+	    'fancyFileInput' => '{{fileInput}}<div class="input-group"><div class="input-group-btn">{{button}}</div>{{input}}</div>',
+	    'confirmJs' => '{{confirm}}'
         ],
         'buttons' => [
             'type' => 'default'


### PR DESCRIPTION
Running the 4.0.1-alpha release and just updated to CakePHP 3.7.1 and received an error

Error: [RuntimeException] Cannot find template named 'confirmJs'.

So have added the confirmJs key to src/View/Helper/FormHelper.php templates array.

https://api.cakephp.org/3.7/class-Cake.View.Helper.HtmlHelper.html