### PR TITLE
Option 'required' is required for _parseOptions()

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -451,6 +451,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
 
         $options += [
             'templateVars' => [],
+            'required'     => false,
             'prepend'      => false,
             'append'       => false,
             'help'         => false,


### PR DESCRIPTION
Option 'required' is required for $this->_parseOptions($fieldName, $options)
Cake 3.7.2
PHP 7.3.1