### PR TITLE
Html injection fix

### DIFF
--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -143,6 +143,7 @@ aria-valuenow="{{width}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}" style=
 	    if(Hash::get($options, 'easyIcon', $this->easyIcon)) {
 		    if ($url !== null && Hash::get($options, 'escape', true)) {
 			    $title = h($title);
+			    $options['escape'] = false;
 		    }
 		    return $this->_easyIcon('parent::link', 0, 2, [$title, $url, $options]);
 	    } else {

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -140,7 +140,7 @@ aria-valuenow="{{width}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}" style=
      * {@inheritDoc}
      */
     public function link($title, $url = null, array $options = []) {
-	    if($this->easyIcon && Hash::get($options, 'easyIcon', true)) {
+	    if(Hash::get($options, 'easyIcon', $this->easyIcon)) {
 		    if ($url !== null && Hash::get($options, 'escape', true)) {
 			    $title = h($title);
 		    }

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -13,6 +13,7 @@
  * @license https://opensource.org/licenses/mit-license.php MIT License
  */
 namespace Bootstrap\View\Helper;
+use Cake\Utility\Hash;
 
 /**
  * Html Helper class for easy use of HTML widgets.
@@ -139,7 +140,14 @@ aria-valuenow="{{width}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}" style=
      * {@inheritDoc}
      */
     public function link($title, $url = null, array $options = []) {
-        return $this->_easyIcon('parent::link', 0, 2, [$title, $url, $options]);
+	    if($this->easyIcon && Hash::get($options, 'easyIcon', true)) {
+		    if ($url !== null && Hash::get($options, 'escape', true)) {
+			    $title = h($title);
+		    }
+		    return $this->_easyIcon('parent::link', 0, 2, [$title, $url, $options]);
+	    } else {
+		    return parent::link($title, $url, $options);
+	    }
     }
 
     /**


### PR DESCRIPTION
Fixes HtmlInjection vulnerability described in  #176

This fix allows escaping without disabling easyIcon conversion.
Escaping is now enabled by default.

Old unsafe behavior can be achieved by setting option `['escape'=>false]` 
Example:
```PHP
echo $this->Html->link('i:tag Title');// new safe behavior
echo $this->Html->link('i:tag Title',['escape'=>false]);//Old unsafe behavior
```

Also icon conversion can be enabled/disabled by passing inline `easyIcon` option
Example:
```PHP
$this->Html->easyIcon = false;
echo $this->Html->link('i:tag Title',['easyIcon'=>false]);//icon won't be converted
echo $this->Html->link('i:tag Title',['easyIcon'=>true]);//icon will be converted
echo $this->Html->link('i:tag Title');//icon won't be converted

$this->Html->easyIcon = true;
echo $this->Html->link('i:tag Title',['easyIcon'=>true]);//icon will be converted
echo $this->Html->link('i:tag Title',['easyIcon'=>false]);//icon won't be converted
echo $this->Html->link('i:tag Title');//icon will be converted

```
