### PR TITLE
FormHelper :: control(), less forceful defaults

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -450,12 +450,21 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
     public function control($fieldName, array $options = array()) {
 
         $options += [
+            'type' => null,
+            'label' => null,
+            'error' => null,
+            'required' => null,
+            'options' => null,
+            'templates' => [],
             'templateVars' => [],
-            'required'     => false,
-            'prepend'      => false,
-            'append'       => false,
-            'help'         => false,
-            'inline'       => false
+            'labelOptions' => true
+        ];
+
+        $options += [
+            'prepend'      => null,
+            'append'       => null,
+            'help'         => null,
+            'inline'       => null
         ];
 
         $options = $this->_parseOptions($fieldName, $options);


### PR DESCRIPTION
Per issue #181.

After migrating from CakePHP 3.4 to 3.7 / 3.8, it took me a while to debug the fact that the ('required' => false) configuration for $options imposed by this package actually TURNS OFF the "required" decorators.

CakePHP's evolved "_magicOptions" function uses:

```
        if (!isset($options['required']) && $options['type'] !== 'hidden') {
            $options['required'] = $context->isRequired($fieldName);
        }
```

... which expects NULL values (ie: neutral, not-yet-decided) instead of FALSE values (already decided in the negative direction).
