### PR TITLE
Fix input type reset

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -449,6 +449,10 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
      */
     public function control($fieldName, array $options = array()) {
 
+        if (!empty($options['type']) and $options['type'] == 'reset') {
+          return $this->submit($fieldName, $options);
+        }
+
         $options += [
             'type' => null,
             'label' => null,


### PR DESCRIPTION
$this->Form->control(__('Reset'), ['type' => reset, class => 'btn btn-default btn-sm']);
Adds to input class form-control.
Before:
`<div class="form-group"><input type="reset" class="form-control btn btn-default btn-sm" value="Reset"></div>`
After:
`<div class="form-group"><input type="reset" class="btn btn-default btn-sm" value="Reset"></div>`