### PR TITLE
WIP: Cake 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
-dist: trusty
+dist: bionic
 
 env:
-  - CAKEPHP_VERSION=3.7.*
-  - CAKEPHP_VERSION=3.8.*
+  - CAKEPHP_VERSION=4.0.*
 
 cache:
   directories:
@@ -24,11 +21,11 @@ before_install:
 install: composer update --prefer-dist --no-interaction
 
 script:
-  - if [[ $TRAVIS_PHP_VERSION = 7.0 ]]; then export CODECOVERAGE=1; vendor/bin/phpunit --coverage-clover=clover.xml; fi
-  - if [[ $TRAVIS_PHP_VERSION != 7.0 ]]; then vendor/bin/phpunit; fi
+  - if [[ $TRAVIS_PHP_VERSION = 7.3 ]]; then export CODECOVERAGE=1; vendor/bin/phpunit --coverage-clover=clover.xml; fi
+  - if [[ $TRAVIS_PHP_VERSION != 7.3 ]]; then vendor/bin/phpunit; fi
 
 after_success:
-  - if [[ $TRAVIS_PHP_VERSION = 7.0 ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - if [[ $TRAVIS_PHP_VERSION = 7.3 ]]; then bash <(curl -s https://codecov.io/bash); fi
 
 notifications:
   email: true

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
     "license": "MIT",
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=5.5.9",
-        "cakephp/cakephp": ">=3.7.0"
+        "php": ">=7.2",
+        "cakephp/cakephp": ">=4.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "<6.0",
+        "phpunit/phpunit": ">=8.0",
         "cakephp/cakephp-codesniffer": "~2.1"
     },
     "autoload": {

--- a/src/Utility/StackedStates.php
+++ b/src/Utility/StackedStates.php
@@ -67,7 +67,7 @@ class StackedStates {
      * ones.
      *
      * @param string $type Type of the new state.
-     * @param mixed $sate New state.
+     * @param mixed $state New state.
      *
      */
     public function push($type, $state = []) {

--- a/src/View/EnhancedStringTemplate.php
+++ b/src/View/EnhancedStringTemplate.php
@@ -41,7 +41,7 @@ class EnhancedStringTemplate extends StringTemplate {
      *
      * @return string
     */
-    public function format($name, array $data) {
+    public function format(string $name, array $data): string {
         if (!isset($this->_compiled[$name])) {
             throw new RuntimeException("Cannot find template named '$name'.");
         }

--- a/src/View/FlexibleStringTemplate.php
+++ b/src/View/FlexibleStringTemplate.php
@@ -54,7 +54,7 @@ class FlexibleStringTemplate extends EnhancedStringTemplate {
      *
      * @return string
     */
-    public function format($name, array $data) {
+    public function format(string $name, array $data): string {
         $name = $this->_getTemplateName($name, $data);
         return parent::format($name, $data);
     }

--- a/src/View/FlexibleStringTemplate.php
+++ b/src/View/FlexibleStringTemplate.php
@@ -38,7 +38,7 @@ class FlexibleStringTemplate extends EnhancedStringTemplate {
      * @param array $config A set of templates to add.
      * @param callable $callback A general callback that will be called before
      * retrieving any templates.
-     * @param arra $callbacks An array of callbacks.
+     * @param array $callbacks An array of callbacks.
      */
     public function __construct(array $config = [], callable $callback = null, array $callbacks = []) {
         parent::__construct($config);

--- a/src/View/FlexibleStringTemplateTrait.php
+++ b/src/View/FlexibleStringTemplateTrait.php
@@ -14,6 +14,8 @@
  */
 namespace Bootstrap\View;
 
+use Cake\View\StringTemplate;
+
 /**
  * Adds string template functionality to any class by providing methods to
  * load and parse string templates.
@@ -29,7 +31,7 @@ trait FlexibleStringTemplateTrait {
      *
      * @return \Cake\View\StringTemplate
      */
-    public function templater() {
+    public function templater(): StringTemplate {
         if ($this->_templater === null) {
             $class = $this->getConfig('templateClass') ?: 'Bootstrap\View\FlexibleStringTemplate';
             $callback = $this->getConfig('templateCallback') ?: null;

--- a/src/View/Helper/ClassTrait.php
+++ b/src/View/Helper/ClassTrait.php
@@ -25,12 +25,12 @@ trait ClassTrait {
      * Adds the given class to the element options.
      *
      * @param array        $options Array of options/attributes to add a class to.
-     * @param string|array $class   The class names to be added.
+     * @param string       $class   The class name to be added.
      * @param string       $key     The key to use for class (default to `'class'`).
      *
      * @return array Array of options with `$key` set or updated.
      */
-    public function addClass(array $options = [], $class = null, $key = 'class') {
+    public function addClass(array $options = [], string $class, string $key = 'class'): array {
         if (!is_array($class)) {
             $class = explode(' ', trim($class));
         }

--- a/src/View/Helper/EasyIconTrait.php
+++ b/src/View/Helper/EasyIconTrait.php
@@ -92,7 +92,7 @@ trait EasyIconTrait {
     /**
      * Inject icon into the given string.
      * 
-     * @param string $input Input string where icon should be injected following the
+     * @param string $title Input string where icon should be injected following the
      * easy-icon process.
      * @param bool $easyIcon Boolean indicating if the easy-icon process should be
      * applied.

--- a/src/View/Helper/FlashHelper.php
+++ b/src/View/Helper/FlashHelper.php
@@ -32,9 +32,9 @@ class FlashHelper extends \Cake\View\Helper\FlashHelper {
     /**
      * {@inheritDoc}
      */
-    public function render($key = 'flash', array $options = []) {
+    public function render($key = 'flash', array $options = []): ?string {
         if (!$this->getView()->getRequest()->getSession()->check("Flash.$key")) {
-            return;
+            return null;
         }
 
         $flash = $this->getView()->getRequest()->getSession()->read("Flash.$key");

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -27,8 +27,8 @@ use Bootstrap\View\FlexibleStringTemplateTrait;
  *
  * @link http://book.cakephp.org/3.0/en/views/helpers/form.html
  */
-class FormHelper extends \Cake\View\Helper\FormHelper {
-
+class FormHelper extends \Cake\View\Helper\FormHelper
+{
     use ClassTrait;
     use EasyIconTrait;
     use FlexibleStringTemplateTrait;
@@ -228,7 +228,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
      *
      * @return string An formatted opening FORM tag.
      */
-    public function create($model = null, Array $options = array()) {
+    public function create($model = null, Array $options = array()): string {
         $options += [
             'horizontal' => false,
             'inline' => false
@@ -371,7 +371,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
         if ($input === null) {
             return $this->formatTemplate('inputGroupStart', ['prepend' => $prepend]);
         }
-        return $this->_wrap($input, $prepend, null);
+        return $this->_wrap($input, $prepend, '');
     }
 
     /**
@@ -389,7 +389,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
         if ($input === null) {
             return $this->formatTemplate('inputGroupEnd', ['append' => $append]);
         }
-        return $this->_wrap($input, null, $append);
+        return $this->_wrap($input, '', $append);
     }
 
     /**
@@ -447,7 +447,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
      *
      * @return string Completed form widget.
      */
-    public function control($fieldName, array $options = array()) {
+    public function control(string $fieldName, array $options = array()): string {
 
         $options += [
             'type' => null,
@@ -500,7 +500,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
     /**
      * {@inheritDoc}
      */
-    protected function _getInput($fieldName, $options) {
+    protected function _getInput(string $fieldName, array $options) {
         $label = $options['labelOptions'];
         switch (strtolower($options['type'])) {
             case 'inlineradio':
@@ -562,7 +562,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
      *
      * @return string A generated file input.
      */
-    public function file($fieldName, array $options = []) {
+    public function file(string $fieldName, array $options = []): string {
         $options += ['secure' => true];
         $options = $this->_initInputField($fieldName, $options);
         unset($options['type']);
@@ -593,7 +593,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
      *
      * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#creating-button-elements
      */
-    public function button($title, array $options = []) {
+    public function button(string $title, array $options = []): string {
         list($options, $easyIcon) = $this->_easyIconOption($options);
         return $this->_injectIcon(parent::button($title, $this->_addButtonClasses($options)), $easyIcon);
     }
@@ -718,7 +718,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
      * @return string A HTML submit button
      * @link http://book.cakephp.org/3.0/en/views/helpers/form.html#creating-buttons-and-submit-elements
      */
-    public function submit($caption = null, array $options = array()) {
+    public function submit(?string $caption = null, array $options = array()): string {
         return parent::submit($caption, $this->_addButtonClasses($options));
     }
 

--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -260,7 +260,7 @@ class FormHelper extends \Cake\View\Helper\FormHelper
      * Set the column sizes configuration associated with the
      * form helper.
      *
-     * @return array
+     * @return $this
      */
     public function setColumnSizes($columns) {
         return $this->setConfig('columns', $columns, false);

--- a/src/View/Helper/HtmlHelper.php
+++ b/src/View/Helper/HtmlHelper.php
@@ -138,7 +138,7 @@ aria-valuenow="{{width}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}" style=
     /**
      * {@inheritDoc}
      */
-    public function link($title, $url = null, array $options = []) {
+    public function link($title, $url = null, array $options = []): string {
         list($options, $easyIcon) = $this->_easyIconOption($options);
         return $this->_injectIcon(parent::link($title, $url, $options), $easyIcon);
     }
@@ -205,16 +205,6 @@ aria-valuenow="{{width}}" aria-valuemin="{{min}}" aria-valuemax="{{max}}" style=
             'attrs' => $this->templater()->formatAttributes($options),
             'templateVars' => $options['templateVars']
         ]);
-    }
-
-
-    /**
-     * @deprecated 3.3.6 (CakePHP) Use the BreadcrumbsHelper instead.
-     */
-    public function getCrumbList(array $options = [], $startText = false) {
-        $options['separator'] = '';
-        $options = $this->addClass($options, 'breadcrumb');
-        return parent::getCrumbList($options, $startText);
     }
 
     /**

--- a/src/View/Helper/ModalHelper.php
+++ b/src/View/Helper/ModalHelper.php
@@ -70,7 +70,7 @@ class ModalHelper extends Helper {
     /**
      * Current part of the modal(`null`, `'header'`, `'body'`, `'footer'`).
      *
-     * @var string
+     * @var string|null
      */
     protected $_current = null;
 
@@ -258,7 +258,7 @@ class ModalHelper extends Helper {
      * - `templateVars` Provide template variables for the `headerStart` template.
      * - Other attributes will be assigned to the modal header element.
      *
-     * @param string $text The modal header content, or null to only open the header.
+     * @param string $title The modal header content, or null to only open the header.
      * @param array $options Array of options. See above.
      *
      * @return string A formated opening tag for the modal header or the complete modal
@@ -368,7 +368,7 @@ class ModalHelper extends Helper {
      * - `templateVars` Provide template variables for the `headerStart` template.
      * - Other attributes will be assigned to the modal header element.
      *
-     * @param string|array $text The modal header content, or an array of options.
+     * @param string|array $info The modal header content, or an array of options.
      * @param array $options Array of options. See above.
      *
      * @return string A formated opening tag for the modal header or the complete modal

--- a/src/View/Helper/NavbarHelper.php
+++ b/src/View/Helper/NavbarHelper.php
@@ -288,7 +288,7 @@ aria-haspopup="true" aria-expanded="false">{{content}}{{caret}}</a>',
      *
      * @param array $options Array of options. See above.
      *
-     * @return A HTML dropdown divider tag.
+     * @return string A HTML dropdown divider tag.
      */
     public function divider(array $options = []) {
         $options += ['templateVars' => []];
@@ -309,7 +309,7 @@ aria-haspopup="true" aria-expanded="false">{{content}}{{caret}}</a>',
      * @param string $name Title of the header.
      * @param array $options Array of options for the wrapper tag.
      *
-     * @return A HTML header tag.
+     * @return string A HTML header tag.
      */
     public function header($name, array $options = []) {
         $options += ['templateVars' => []];

--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -86,7 +86,7 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper {
      * @param array $options Options from the numbers() method.
      * @return array An array with the start and end numbers.
      */
-    protected function _getNumbersStartAndEnd($params, $options) {
+    protected function _getNumbersStartAndEnd(array $params, array $options): array {
         $half = (int)($options['modulus'] / 2);
         $end = max(1 + $options['modulus'], $params['page'] + $half);
         $start = min($params['pageCount'] - $options['modulus'], $params['page'] - $half - $options['modulus'] % 2);
@@ -153,7 +153,7 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper {
      * @return string numbers string.
      * @link http://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-page-number-links
      */
-    public function numbers(array $options = []) {
+    public function numbers(array $options = []): string {
 
         $defaults = [
             'before' => null, 'after' => null, 'model' => $this->defaultModel(),
@@ -180,7 +180,7 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper {
 
         $params = (array)$this->params($options['model']) + ['page' => 1];
         if ($params['pageCount'] <= 1) {
-            return false;
+            return '';
         }
 
         $templater = $this->templater();
@@ -274,7 +274,7 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper {
      *
      * @link http://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-jump-links
      */
-    public function prev($title = '<< Previous', array $options = []) {
+    public function prev(string $title = '<< Previous', array $options = []): string {
         list($options, $easyIcon) = $this->_easyIconOption($options);
         return $this->_injectIcon(parent::prev($title, $options), $easyIcon);
     }
@@ -301,7 +301,7 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper {
      *
      * @link http://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-jump-links
      */
-    public function next($title = 'Next >>', array $options = []) {
+    public function next(string $title = 'Next >>', array $options = []): string {
         list($options, $easyIcon) = $this->_easyIconOption($options);
         return $this->_injectIcon(parent::next($title, $options), $easyIcon);
     }
@@ -337,7 +337,7 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper {
      *
      * @link http://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-jump-links
      */
-    public function first($first = '<< first', array $options = []) {
+    public function first($first = '<< first', array $options = []): string {
         list($options, $easyIcon) = $this->_easyIconOption($options);
         return $this->_injectIcon(parent::first($first, $options), $easyIcon);
     }
@@ -373,7 +373,7 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper {
      *
      * @link http://book.cakephp.org/3.0/en/views/helpers/paginator.html#creating-jump-links
      */
-    public function last($last = 'last >>', array $options = []) {
+    public function last($last = 'last >>', array $options = []): string {
         list($options, $easyIcon) = $this->_easyIconOption($options);
         return $this->_injectIcon(parent::last($last, $options), $easyIcon);
     }

--- a/src/View/Helper/PanelHelper.php
+++ b/src/View/Helper/PanelHelper.php
@@ -350,7 +350,7 @@ class PanelHelper extends Helper {
      * - `templateVars` Provide template variables for the header template.
      * - Other attributes will be assigned to the header element.
      *
-     * @param string $text The panel header content, or null to only open the header.
+     * @param string $title The panel header content, or null to only open the header.
      * @param array $options Array of options. See above.
      *
      * @return string A formated opening tag for the panel header or the complete panel
@@ -529,7 +529,7 @@ class PanelHelper extends Helper {
      * - `templateVars` Provide template variables for the header template.
      * - Other attributes will be assigned to the header element.
      *
-     * @param string|array $text The header content, or `null`, or an array of options.
+     * @param string|array $info The header content, or `null`, or an array of options.
      * @param array        $options Array of options. See above.
      *
      * @return string A formated opening tag for the panel header or the complete panel
@@ -575,7 +575,7 @@ class PanelHelper extends Helper {
      * - `templateVars` Provide template variables for the body template.
      * - Other attributes will be assigned to the body element.
      *
-     * @param array|string $info The body content, or `null`, or an array of options.
+     * @param array|string $content The body content, or `null`, or an array of options.
      * `$options`.
      * @param array $options Array of options for the panel body `<div>`.
      *

--- a/src/View/Helper/UrlComparerTrait.php
+++ b/src/View/Helper/UrlComparerTrait.php
@@ -90,7 +90,7 @@ trait UrlComparerTrait {
      *
      * @param string $url URL from which the relative part should be removed.
      *
-     * @param string The new URL.
+     * @return string The new URL.
      */
     protected function _removeRelative($url) {
         $components = parse_url($url);
@@ -106,9 +106,9 @@ trait UrlComparerTrait {
      * Normalize an URL.
      *
      * @param string $url URL to normalize.
-     * @param array $pass Include pass parameters.
+     * @param array $parts Include pass parameters.
      *
-     * @return string Normalized URL.
+     * @return string|null Normalized URL.
      */
     protected function _normalize($url, array $parts = []) {
         if (!is_string($url)) {

--- a/src/View/Widget/ColumnSelectBoxWidget.php
+++ b/src/View/Widget/ColumnSelectBoxWidget.php
@@ -50,7 +50,7 @@ class ColumnSelectBoxWidget extends SelectBoxWidget {
      * @return string A generated select box.
      * @throws \RuntimeException when the name attribute is empty.
      */
-    public function render(array $data, \Cake\View\Form\ContextInterface $context)
+    public function render(array $data, \Cake\View\Form\ContextInterface $context): string
     {
         $data += [
             'name' => '',

--- a/src/View/Widget/DateTimeWidget.php
+++ b/src/View/Widget/DateTimeWidget.php
@@ -73,7 +73,7 @@ class DateTimeWidget extends \Cake\View\Widget\DateTimeWidget {
      * @return string A generated select box.
      * @throws \RuntimeException When option data is invalid.
      */
-    public function render(array $data, \Cake\View\Form\ContextInterface $context) {
+    public function render(array $data, \Cake\View\Form\ContextInterface $context): string {
         $data = $this->_normalizeData($data);
         $count = 0;
         foreach ($this->_selects as $select) {

--- a/src/View/Widget/FancyFileWidget.php
+++ b/src/View/Widget/FancyFileWidget.php
@@ -90,7 +90,7 @@ class FancyFileWidget implements WidgetInterface {
      * @param \Cake\View\Form\ContextInterface $context The current form context.
      * @return string HTML elements.
      */
-    public function render(array $data, \Cake\View\Form\ContextInterface $context) {
+    public function render(array $data, \Cake\View\Form\ContextInterface $context): string {
 
         $data += [
             '_input'  => [],
@@ -159,7 +159,7 @@ class FancyFileWidget implements WidgetInterface {
     /**
      * {@inheritDoc}
      */
-    public function secureFields(array $data) {
+    public function secureFields(array $data): array {
         // the extra input for display
         $fields = [$this->_fakeFieldName($data['name'])];
         // the file array

--- a/src/View/Widget/FancyFileWidget.php
+++ b/src/View/Widget/FancyFileWidget.php
@@ -35,21 +35,21 @@ class FancyFileWidget implements WidgetInterface {
     /**
      * FileWidget instance.
      *
-     * @var Cake\View\Widget\FileWidget
+     * @var \Cake\View\Widget\FileWidget
      */
     protected $_file;
 
     /**
      * ButtonWidget instance.
      *
-     * @var Cake\View\Widget\ButtonWidget
+     * @var \Cake\View\Widget\ButtonWidget
      */
     protected $_button;
 
     /**
      * Text widget instance.
      *
-     * @var Cake\View\Widget\BasicWidget
+     * @var \Cake\View\Widget\BasicWidget
      */
     protected $_input;
 

--- a/src/View/Widget/InlineRadioWidget.php
+++ b/src/View/Widget/InlineRadioWidget.php
@@ -33,7 +33,7 @@ class InlineRadioWidget extends RadioWidget {
      * @param \Cake\View\Form\ContextInterface $context The form context
      * @return string
      */
-    protected function _renderInput($val, $text, $data, $context) {
+    protected function _renderInput($val, $text, $data, $context): string {
         $escape = $data['escape'];
         if (is_int($val) && isset($text['text'], $text['value'])) {
             $radio = $text;

--- a/tests/TestCase/Utility/MatchingTest.php
+++ b/tests/TestCase/Utility/MatchingTest.php
@@ -12,7 +12,7 @@ class MatchingTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
     }
 

--- a/tests/TestCase/Utility/StackedStatesTest.php
+++ b/tests/TestCase/Utility/StackedStatesTest.php
@@ -19,7 +19,7 @@ class StackedStatesTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         $this->states = new StackedStates();
     }
 

--- a/tests/TestCase/View/EnhancedStringTemplateTest.php
+++ b/tests/TestCase/View/EnhancedStringTemplateTest.php
@@ -20,7 +20,7 @@ class EnhancedStringTemplateTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->templater = new EnhancedStringTemplate();
     }

--- a/tests/TestCase/View/Helper/BootstrapAliasesTest.php
+++ b/tests/TestCase/View/Helper/BootstrapAliasesTest.php
@@ -11,7 +11,7 @@ class BootstrapAliasesTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
 
     }
 

--- a/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
+++ b/tests/TestCase/View/Helper/BreadcrumbsHelperTest.php
@@ -20,7 +20,7 @@ class BreadcrumbsHelperTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $view = new View();
         $this->breadcrumbs = new BreadcrumbsHelper($view);

--- a/tests/TestCase/View/Helper/ClassTraitTest.php
+++ b/tests/TestCase/View/Helper/ClassTraitTest.php
@@ -29,7 +29,7 @@ class BootstrapTraitTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $view = new View();
         $this->trait = new PublicClassTrait($view);

--- a/tests/TestCase/View/Helper/EasyIconTraitTest.php
+++ b/tests/TestCase/View/Helper/EasyIconTraitTest.php
@@ -58,7 +58,7 @@ class EasyIconTraitTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $view = new View();
         $view->loadHelper('Html', [

--- a/tests/TestCase/View/Helper/FormHelperTest.php
+++ b/tests/TestCase/View/Helper/FormHelperTest.php
@@ -21,7 +21,7 @@ class FormHelperTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $view = new View();
         $view->loadHelper('Html', [

--- a/tests/TestCase/View/Helper/HtmlHelperTest.php
+++ b/tests/TestCase/View/Helper/HtmlHelperTest.php
@@ -20,7 +20,7 @@ class HtmlHelperTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $view = new View();
         $this->html = new HtmlHelper($view);

--- a/tests/TestCase/View/Helper/ModalHelperTest.php
+++ b/tests/TestCase/View/Helper/ModalHelperTest.php
@@ -20,7 +20,7 @@ class ModalHelperTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $view = new View();
         $view->loadHelper('Html', [

--- a/tests/TestCase/View/Helper/NavbarHelperTest.php
+++ b/tests/TestCase/View/Helper/NavbarHelperTest.php
@@ -25,7 +25,7 @@ class NavbarHelperTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $view = new View();
         $view->loadHelper('Html', [

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -30,7 +30,7 @@ class PaginatorHelperTest extends TestCase {
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $request = new ServerRequest([

--- a/tests/TestCase/View/Helper/PanelHelperTest.php
+++ b/tests/TestCase/View/Helper/PanelHelperTest.php
@@ -21,7 +21,7 @@ class PanelHelperTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $view = new View();
         $view->loadHelper('Html', [

--- a/tests/TestCase/View/Helper/UrlComparerTraitTest.php
+++ b/tests/TestCase/View/Helper/UrlComparerTraitTest.php
@@ -34,7 +34,7 @@ class UrlComparerTraitTest extends TestCase {
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         Configure::write('debug', true);
         Router::scope('/', function (RouteBuilder $routes) {


### PR DESCRIPTION
This fixes a few breaking changes for Cake 4.x and uses Bootstrap3 as its base. I've updated all the broken return types I could find, and fixed a few docblock mistakes. On a cursory glance, it works as expected in my app, but I didn't yet test all the features.

BC breaks:
* `DateTimeWidget` is currently broken since Cake 4 migrated to HTML 5 inputs instead of selects. I'm not using this feature, so I probably won't fix it.
* `ClassTrait::addClass()` drops support for array class arguments to conform to Cake 4
* Deprecated `HtmlHelper::getCrumbsList()` was removed