### PR TITLE
Add `selected` template as defined in CakePHP 3.9

### DIFF
--- a/src/View/Helper/FormHelper.php
+++ b/src/View/Helper/FormHelper.php
@@ -118,7 +118,8 @@ class FormHelper extends \Cake\View\Helper\FormHelper {
             'helpBlock' => '<p class="help-block">{{content}}</p>',
             'buttonGroup' => '<div class="btn-group{{attrs.class}}"{{attrs}}>{{content}}</div>',
             'buttonToolbar' => '<div class="btn-toolbar{{attrs.class}}"{{attrs}}>{{content}}</div>',
-            'fancyFileInput' => '{{fileInput}}<div class="input-group"><div class="input-group-btn">{{button}}</div>{{input}}</div>'
+            'fancyFileInput' => '{{fileInput}}<div class="input-group"><div class="input-group-btn">{{button}}</div>{{input}}</div>',
+            'selectedClass' => 'selected',
         ],
         'buttons' => [
             'type' => 'default'


### PR DESCRIPTION
Update the template array in FormHelper, added in 3.9 in cakephp/cakephp#13686

Otherwise it throws a RuntimeException when using MultipleCheckbox

